### PR TITLE
Add setup file for setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To install the package from master run
 pipenv install -e git+https://github.com/ONSdigital/census-rm-qid-batch-runner#egg=census-rm-qid-batch-runner
 ```
 
-But note that pipenv locks with the commit hash as a ref, so any further commits to master in this repo will cause a pipenv install --deploy to fail until it is relocked since the remote ref will have changed.
+But note that pipenv locks with the commit hash as a ref, so any further commits to master in this repo will cause a `pipenv install --deploy` to fail until it is relocked since the remote ref will have changed.
 
 ### Install a release
 To install the package from a release tag run 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ This repo contains a setup.py so that it can be installed through pip/pipenv as 
 ### Install from master
 To install the package from master run 
 ```bash
-pipenv install -e git+https://github.com/ONSdigital/census-rm-qid-batch-runner#egg=census-rm-qid-batch-runner
+pipenv install -e git+https://github.com/ONSdigital/census-rm-qid-batch-runner#egg=census_rm_qid_batch_runner
 ```
 
 But note that pipenv locks with the commit hash as a ref, so any further commits to master in this repo will cause a `pipenv install --deploy` to fail until it is relocked since the remote ref will have changed.
@@ -113,5 +113,5 @@ But note that pipenv locks with the commit hash as a ref, so any further commits
 ### Install a release
 To install the package from a release tag run 
 ```bash
-pipenv install -e git+https://github.com/ONSdigital/census-rm-qid-batch-runner@<RELEASE TAG>#egg=census-rm-qid-batch-runner
+pipenv install -e git+https://github.com/ONSdigital/census-rm-qid-batch-runner@<RELEASE TAG>#egg=census_rm_qid_batch_runner
 ```

--- a/README.md
+++ b/README.md
@@ -98,3 +98,20 @@ Build the image tagged as `eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner:
 ```bash
 make build
 ```
+
+## Importing this code as a package
+This repo contains a setup.py so that it can be installed through pip/pipenv as a github VCS dependency
+
+### Install from master
+To install the package from master run 
+```bash
+pipenv install -e git+https://github.com/ONSdigital/census-rm-qid-batch-runner#egg=census-rm-qid-batch-runner
+```
+
+But note that pipenv locks with the commit hash as a ref, so any further commits to master in this repo will cause a pipenv install --deploy to fail until it is relocked since the remote ref will have changed.
+
+### Install a release
+To install the package from a release tag run 
+```bash
+pipenv install -e git+https://github.com/ONSdigital/census-rm-qid-batch-runner@<RELEASE TAG>#egg=census-rm-qid-batch-runner
+```

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-name = 'census-rm-qid-batch-runner'
+name = 'census_rm_qid_batch_runner'

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+name = 'census-rm-qid-batch-runner'

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import setuptools
+
+setuptools.setup(
+    name="census-rm-qid-batch-runner",
+    version="0.0.1",
+    author="Adam Hawtin",
+    author_email="adam.hawtin@qa.com",
+    description="Scripts to request qid pairs and generate print files",
+    long_description=Path('README.md').read_text(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/ONSdigital/census-rm-qid-batch-runner/tree/setup-for-importing",
+    packages=setuptools.find_packages(),
+)

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@ import setuptools
 setuptools.setup(
     name="census-rm-qid-batch-runner",
     version="0.0.1",
-    author="Adam Hawtin",
-    author_email="adam.hawtin@qa.com",
     description="Scripts to request qid pairs and generate print files",
     long_description=Path('README.md').read_text(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import setuptools
 
 setuptools.setup(
-    name="census-rm-qid-batch-runner",
+    name="census_rm_qid_batch_runner",
     version="0.0.1",
     description="Scripts to request qid pairs and generate print files",
     long_description=Path('README.md').read_text(),

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setuptools.setup(
     description="Scripts to request qid pairs and generate print files",
     long_description=Path('README.md').read_text(),
     long_description_content_type="text/markdown",
-    url="https://github.com/ONSdigital/census-rm-qid-batch-runner/tree/setup-for-importing",
+    url="https://github.com/ONSdigital/census-rm-qid-batch-runner",
     packages=setuptools.find_packages(),
 )


### PR DESCRIPTION
# Motivation and Context
We want to reuse this code else where. Adding a setup.py will allow it to be installed as a dependency through pip's VCS support so the code can be imported as a module. This is just a proof of concept of the idea, not necessarily ready to merge.

# What has changed
- Add setup and init to allow installation through pip/pipenv's VCS source support

# How to test?
Try and build the linked branches which have this branch installed as a dependency

# Links
https://github.com/ONSdigital/census-rm-ops/pull/11
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/65
https://trello.com/c/GgRSVlOY/795-importing-python-modules-from-github-repos-1-hour#