### PR TITLE
Make SFTP target directory configurable

### DIFF
--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -63,13 +63,11 @@ spec:
               secretKeyRef:
                 name: db-credentials
                 key: password
-          - name: PROJECT_NAME
+          - name: SFTP_DIRECTORY
             valueFrom:
               configMapKeyRef:
-                key: project-name
+                key: sftp-target-directory
                 name: project-config
-          - name: SFTP_DIRECTORY
-            value: "$(PROJECT_NAME)/upload"
           - name: SFTP_HOST
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
# Motivation and Context
SFTP target directory needs to be easily configurable between different environments (e.g. CI, WL, BL, Prod etc)

# What has changed
Use k8s configmap parameter to configure the target SFTP directory.

# How to test?
Build an environment with branch `sftp-target-directory-config` on `census-rm-terraform` and `census-rm-kubernates`. Run the tests.

# Links
Trello: https://trello.com/c/jTMYmVyo

# Screenshots (if appropriate):