### PR TITLE
Update k8s deployment manifest

### DIFF
--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -21,8 +21,8 @@ spec:
       - name: qid-batch-runner
         image: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner:latest
         imagePullPolicy: Always
-        command: [ "python", "-c" ]
-        args: [ "while 1:0" ]
+        tty: true
+        stdin: true
         env:
           - name: RABBITMQ_SERVICE_HOST
             value: rabbitmq
@@ -101,6 +101,13 @@ spec:
           - name: pgp-keys
             mountPath: "/root/.pgp-keys"
             readOnly: true
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "512Mi"
+          limits:
+            cpu: "1000m"
+            memory: "2048Mi"
       volumes:
         - name: cloud-sql-certs
           secret:


### PR DESCRIPTION
# Motivation and Context
The previous version runs a loop constantly causing the pod to consume CPU resource it doesn't need.

# What has changed
 * Update deployment manifest

# How to test?
Run through an unaddressed batch, before and after check the CPU usage drops when the pod is not running anything

# Links
https://trello.com/c/vr0EdmaM/868-bug-qid-batch-runner-constantly-uses-cpu-at-rest