### PR TITLE
Fixes for tester raised defects

### DIFF
--- a/generate_print_files.py
+++ b/generate_print_files.py
@@ -17,9 +17,9 @@ import sftp
 from encryption import pgp_encrypt_message
 from exceptions import QidQuantityMismatchException
 
-
-PRINT_FILE_TEMPLATE = ('UAC', 'QUESTIONNAIRE_ID', 'WALES_UAC', 'WALES_QUESTIONNAIRE_ID', 'TITLE', 'FORENAME', 'SURNAME',
-                       'ADDRESS_LINE1', 'ADDRESS_LINE2', 'ADDRESS_LINE3', 'TOWN_NAME', 'POSTCODE', 'PRODUCTPACK_CODE')
+PRINT_FILE_TEMPLATE = (
+    'UAC', 'QUESTIONNAIRE_ID', 'WALES_UAC', 'WALES_QUESTIONNAIRE_ID', 'TITLE', 'COORDINATOR_ID', 'FORENAME', 'SURNAME',
+    'ADDRESS_LINE1', 'ADDRESS_LINE2', 'ADDRESS_LINE3', 'TOWN_NAME', 'POSTCODE', 'PRODUCTPACK_CODE')
 
 PRODUCTPACK_CODE_TO_DESCRIPTION = {
     'D_FD_H1': 'Household Questionnaire pack for England',
@@ -120,7 +120,7 @@ def create_manifest(print_file_path: Path, productpack_code: str) -> dict:
         'files': [
             {
                 'name': print_file_path.name,
-                'relativePath': print_file_path.name,  # TODO Match this to SFTP directory structure
+                'relativePath': f'./{print_file_path.name}',
                 'sourceName': 'ONS_RM',
                 'sizeBytes': str(print_file_path.stat().st_size)
             }

--- a/tests/test_generate_print_files.py
+++ b/tests/test_generate_print_files.py
@@ -31,9 +31,9 @@ def test_generate_print_files_from_config_file_path_generates_correct_print_file
     with our_key.unlock(passphrase='test'):
         message_1 = our_key.decrypt(encrypted_message_1).message
         message_2 = our_key.decrypt(encrypted_message_2).message
-    assert message_1 == ('test_uac_1|test_qid_1|||||||||||D_FD_H1\r\n'
-                         'test_uac_2|test_qid_2|||||||||||D_FD_H1\r\n')
-    assert message_2 == 'test_uac_3|test_qid_3|||||||||||D_FD_H2\r\n'
+    assert message_1 == ('test_uac_1|test_qid_1||||||||||||D_FD_H1\r\n'
+                         'test_uac_2|test_qid_2||||||||||||D_FD_H1\r\n')
+    assert message_2 == 'test_uac_3|test_qid_3||||||||||||D_FD_H2\r\n'
 
 
 def test_generate_print_files_from_config_file_path_errors_on_qid_quantity_mismatch(cleanup_test_files,
@@ -70,12 +70,14 @@ def test_generate_print_files_from_config_file_path_generates_correct_manifests(
     assert manifest_1['description'] == 'Household Questionnaire pack for England'
     assert manifest_1['files'][0]['sizeBytes'] == '1634'
     assert manifest_1['files'][0]['name'] == f'{manifest_file_1.stem}.csv'
+    assert manifest_1['files'][0]['relativePath'].startswith('./')
 
     manifest_file_2 = next(cleanup_test_files.glob('D_FD_H2*.manifest'))
     manifest_2 = json.loads(manifest_file_2.read_text())
     assert manifest_2['description'] == 'Household Questionnaire pack for Wales (English)'
     assert manifest_2['files'][0]['sizeBytes'] == '1626'
     assert manifest_2['files'][0]['name'] == f'{manifest_file_2.stem}.csv'
+    assert manifest_1['files'][0]['relativePath'].startswith('./')
 
 
 def test_copy_files_to_gcs():


### PR DESCRIPTION
# What has changed
* Start relative path in manifest with ./
* Include column for coordinator ID

# How to test?
Build the docker image and try running in a k8s cluster, the print files should have an extra empty column in every row and the manifest relative path fields should now start with './'

# Links
https://trello.com/c/0hZ2duVl/885-defect-missing-column-in-unaddressed-print-file-coordinator-id-missing
https://trello.com/c/8tkxZebD/886-defect-relative-path-with-in-manifest-file-must-start-with-filepath
