### PR TITLE
Amend relative path to not include full file path

### DIFF
--- a/generate_print_files.py
+++ b/generate_print_files.py
@@ -120,7 +120,7 @@ def create_manifest(print_file_path: Path, productpack_code: str) -> dict:
         'files': [
             {
                 'name': print_file_path.name,
-                'relativePath': f'./{print_file_path.name}',
+                'relativePath': './',
                 'sourceName': 'ONS_RM',
                 'sizeBytes': str(print_file_path.stat().st_size)
             }


### PR DESCRIPTION
# Motivation and Context
The relative path should not include the filename, just `./`

# Links
https://trello.com/c/8tkxZebD/886-defect-relative-path-with-in-manifest-file-must-start-with-filepath
#12 
