### PR TITLE
Remove docker push from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,13 @@ install:
   - pipenv install --dev --deploy
 
 script:
-  - make test
+  - make build
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    docker build -t "$DESTINATION_IMAGE_NAME" .;
-    docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-    docker push "$DESTINATION_IMAGE_NAME";
-    fi
-
   - bash <(curl -s https://codecov.io/bash)
 
 env:
   global:
-    - DESTINATION_IMAGE_NAME="eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner"
     - PIPENV_IGNORE_VIRTUALENVS=1
 
 branches:


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Concourse will now handle the building and pushing of our Docker services to GCR.

## What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added fail on docker build (after test) to script section of Travis file
