### PR TITLE
Update to use the qm supplier public key from the secret

### DIFF
--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -127,5 +127,5 @@ spec:
             items:
               - key: our-public-key
                 path: "our_public_key.asc"
-              - key: other-public-key
+              - key: qm-supplier-public-key
                 path: "other_public_key.asc"

--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -66,7 +66,7 @@ spec:
           - name: SFTP_DIRECTORY
             valueFrom:
               configMapKeyRef:
-                key: sftp-target-directory
+                key: sftp-qm-supplier-directory
                 name: project-config
           - name: SFTP_HOST
             valueFrom:


### PR DESCRIPTION
# Motivation and Context
The pgp-keys secret has changed, this service now needs to point it's config at the qm supplier key. Also the SFTP directory now needs to point at the QM supplier directory.

# What has changed
* Use the QM supplier key as the 'other' key in the k8s manifest
* Use the QM supplier SFTP directory in the k8s manifest

# How to test?
Run acceptance tests on the branches on this card: https://trello.com/c/xgyARfxB/907-add-distribution-functionality-to-print-file-service-8

# Links
https://trello.com/c/xgyARfxB/907-add-distribution-functionality-to-print-file-service-8
https://github.com/ONSdigital/census-rm-terraform/pull/73/files