### PR TITLE
Change to using a single dump file with multiple lines

### DIFF
--- a/dump_files_to_queue.py
+++ b/dump_files_to_queue.py
@@ -4,10 +4,21 @@ from pathlib import Path
 from rabbit_context import RabbitContext
 
 
-def publish_messages_from_config_file_path(queue_name, source_file_path, destination_file_path):
+def publish_messages_from_json_file_path(queue_name: str, source_file_path: Path, destination_file_path: Path):
+    """
+    NB: this exists to support the single (JSON) file model and should not be used with the new style (dump) files
+    """
     with RabbitContext(queue_name=queue_name) as rabbit:
         for file_path in source_file_path.rglob('*.json'):
             rabbit.publish_message(file_path.read_text(), 'application/json')
+            file_path.replace(destination_file_path.joinpath(file_path.name))
+
+
+def publish_messages_from_dump_files(queue_name: str, source_file_path: Path, destination_file_path: Path):
+    with RabbitContext(queue_name=queue_name) as rabbit:
+        for file_path in source_file_path.rglob('*.dump'):
+            for json_message in file_path.open():
+                rabbit.publish_message(json_message, 'application/json')
             file_path.replace(destination_file_path.joinpath(file_path.name))
 
 
@@ -17,12 +28,17 @@ def parse_arguments():
     parser.add_argument('queue_name', help='Name of queue to publish to', type=str)
     parser.add_argument('source_file_path', help='Directory to read input files from', type=Path)
     parser.add_argument('destination_file_path', help='Directory to move published input files to', type=Path)
+    parser.add_argument('--separate-files', help="Each message has its own (JSON) file [LEGACY]", required=False,
+                        action='store_true')
     return parser.parse_args()
 
 
 def main():
     args = parse_arguments()
-    publish_messages_from_config_file_path(args.queue_name, args.source_file_path, args.destination_file_path)
+    if args.separate_files:
+        publish_messages_from_json_file_path(args.queue_name, args.source_file_path, args.destination_file_path)
+    else:
+        publish_messages_from_dump_files(args.queue_name, args.source_file_path, args.destination_file_path)
 
 
 if __name__ == '__main__':

--- a/dump_queue_to_files.py
+++ b/dump_queue_to_files.py
@@ -9,6 +9,7 @@ from google.cloud import storage
 
 from rabbit_context import RabbitContext
 
+
 queue_quantity = 0
 
 
@@ -25,17 +26,18 @@ def start_listening_to_rabbit_queue(queue, on_message_callback):
 def dump_messages(queue_name, output_file_path):
     directory_path = output_file_path.joinpath(f'{queue_name}_{datetime.utcnow().strftime("%Y-%M-%dT%H-%M-%S")}')
     directory_path.mkdir()
+    output_file_path = directory_path.joinpath(f'{str(uuid.uuid4())}.dump')
     print(f'Writing messages to path: {directory_path.stem}')
     print(f'Started processing Rabbit messages on queue {queue_name}')
     start_listening_to_rabbit_queue(queue_name,
                                     functools.partial(_rabbit_message_received_callback,
-                                                      output_file_path=directory_path))
+                                                      output_file_path=output_file_path))
     return directory_path
 
 
-def _rabbit_message_received_callback(ch, method, _properties, body, output_file_path):
-    output_file = output_file_path.joinpath(f'{str(uuid.uuid4())}.json')
-    output_file.write_text(body.decode("utf-8"))
+def _rabbit_message_received_callback(ch, method, _properties, body: bytes, output_file_path: Path):
+    with output_file_path.open('a') as fp:
+        fp.write(f'{body.decode("utf-8")}\n')
     ch.basic_ack(delivery_tag=method.delivery_tag)
 
     global queue_quantity

--- a/tests/test_dump_files_to_queue.py
+++ b/tests/test_dump_files_to_queue.py
@@ -2,25 +2,27 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-from dump_files_to_queue import publish_messages_from_config_file_path
+from dump_files_to_queue import publish_messages_from_dump_files
 
 
 def test_publish_messages_from_config_file_path(cleanup_test_files):
     resource_file_path = Path(__file__).parent.resolve().joinpath('resources')
-    test_message_path = resource_file_path.joinpath('test_message.json')
-    test_message_path.write_text('{"foo":"bar"}')
+    test_message_path = resource_file_path.joinpath('test_message.dump')
+    test_text = ('{"first_item":"1"}\n', '{"second_item":"2"}\n')
+    with test_message_path.open('w') as fh:
+        fh.writelines(test_text)
 
     with patch('dump_files_to_queue.RabbitContext') as patch_rabbit:
-        publish_messages_from_config_file_path("dummy", resource_file_path, cleanup_test_files)
+        publish_messages_from_dump_files("dummy", resource_file_path, cleanup_test_files)
 
-    index = 0
+    for file_count, file_path in enumerate(cleanup_test_files.rglob('*.dump'), 1):
+        with file_path.open() as message_file:
+            for file_line, test_line in zip(list(message_file), test_text):
+                assert file_line == test_line
 
-    for index, file_path in enumerate(cleanup_test_files.rglob('*.json')):
-        with open(file_path) as message_file:
-            assert '{"foo":"bar"}' == message_file.read()
-
-    assert index + 1 == 1
+    assert file_count == 1, "should be a single *.dump file"
 
     call_list = patch_rabbit.return_value.__enter__.return_value.publish_message.call_args_list
-    assert len(call_list) == 1
-    assert json.loads(call_list[0][0][0])['foo'] == 'bar'
+    assert len(call_list) == 2
+    assert json.loads(call_list[0][0][0])['first_item'] == '1'
+    assert json.loads(call_list[1][0][0])['second_item'] == '2'

--- a/tests/test_dump_queue_to_files.py
+++ b/tests/test_dump_queue_to_files.py
@@ -1,15 +1,21 @@
+import json
+import uuid
+from pathlib import Path
 from unittest.mock import Mock
 
 from dump_queue_to_files import _rabbit_message_received_callback
 
 
-def test_rabbit_message_consume(cleanup_test_files):
-    _rabbit_message_received_callback(Mock(), Mock(), None, b'{"key":"value"}', cleanup_test_files)
+def test_rabbit_message_consume(cleanup_test_files: Path):
+    output_file_path = cleanup_test_files.joinpath(f'{str(uuid.uuid4())}.dump')
 
-    index = 0
+    for i in range(5):  # simulate publishing 5 messages
+        message = f'{{"{i}_entry":"{i}_value"}}'.encode('utf-8')
+        _rabbit_message_received_callback(Mock(), Mock(), None, message, output_file_path)
 
-    for index, file_path in enumerate(cleanup_test_files.rglob('*.json')):
-        with open(file_path) as message_file:
-            assert '{"key":"value"}' == message_file.read()
+    for file_count, file_path in enumerate(cleanup_test_files.rglob('*.dump'), start=1):
+        with file_path.open() as message_file:
+            for index, message_line in enumerate(message_file):
+                assert json.loads(message_line)[f'{index}_entry'] == f'{index}_value'
 
-    assert index + 1 == 1
+    assert file_count == 1, "should only be a single *.dump file"


### PR DESCRIPTION
New multi-line *.dump file implementation.

NB: Added handling the restoration of old-style *.json files with `--separate-files` in the `dump_files_to_queue.py` script.