### PR TITLE
Fix Defect: Date on filename is incorrect for files

### DIFF
--- a/dump_queue_to_files.py
+++ b/dump_queue_to_files.py
@@ -23,8 +23,8 @@ def start_listening_to_rabbit_queue(queue, on_message_callback):
     rabbit.channel.start_consuming()
 
 
-def dump_messages(queue_name, output_file_path):
-    directory_path = output_file_path.joinpath(f'{queue_name}_{datetime.utcnow().strftime("%Y-%M-%dT%H-%M-%S")}')
+def dump_messages(queue_name, output_file_path) -> Path:
+    directory_path = output_file_path.joinpath(f'{queue_name}_{datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%S")}')
     directory_path.mkdir()
     output_file_path = directory_path.joinpath(f'{str(uuid.uuid4())}.dump')
     print(f'Writing messages to path: {directory_path.stem}')

--- a/tests/test_dump_queue_to_files.py
+++ b/tests/test_dump_queue_to_files.py
@@ -1,9 +1,10 @@
 import json
 import uuid
+from datetime import datetime
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from dump_queue_to_files import _rabbit_message_received_callback
+from dump_queue_to_files import _rabbit_message_received_callback, dump_messages
 
 
 def test_rabbit_message_consume(cleanup_test_files: Path):
@@ -18,4 +19,14 @@ def test_rabbit_message_consume(cleanup_test_files: Path):
             for index, message_line in enumerate(message_file):
                 assert json.loads(message_line)[f'{index}_entry'] == f'{index}_value'
 
-    assert file_count == 1, "should only be a single *.dump file"
+    assert file_count == 1, f"should only be a single *.dump file (not {file_count} files)"
+
+
+def test_directory_path_name(cleanup_test_files: Path):
+    test_datetime = datetime(2019, 8, 30, 17, 00, 00, 0)
+    with patch('dump_queue_to_files.datetime') as patched_dt:
+        patched_dt.utcnow.return_value = test_datetime
+        with patch('dump_queue_to_files.RabbitContext'):
+            directory_path = dump_messages('test-queue', cleanup_test_files)
+
+    assert 'test-queue_2019-08-30T17-00-00' in str(directory_path)


### PR DESCRIPTION
Running `dump_queue_to_files.py`, the file and zip file are named incorrectly (the month is incorrect):

Name is:
case.rh.case_2019-**35**-14T13-35-05 instead of 
case.rh.case_2019-**08**-14T13-35-05

This is identical to a previous issue that has been raised and fixed elsewhere in this repo:

https://trello.com/c/44XrGvKb
https://github.com/ONSdigital/census-rm-qid-batch-runner/pull/14/files