### PR TITLE
Persistent Delivery Mode added for all publish_message functions in r…

### DIFF
--- a/rabbit_context.py
+++ b/rabbit_context.py
@@ -51,8 +51,7 @@ class RabbitContext:
             exchange=self._exchange,
             routing_key=self.queue_name,
             body=message,
-            properties=pika.BasicProperties(content_type=content_type, headers=headers,
-                                            delivery_mode=PERSISTENT_DELIVERY_MODE))
+            properties=pika.BasicProperties(content_type=content_type, delivery_mode=PERSISTENT_DELIVERY_MODE))
 
 
 class RabbitConnectionClosedError(Exception):

--- a/rabbit_context.py
+++ b/rabbit_context.py
@@ -1,6 +1,7 @@
 import os
 
 import pika
+from pika.spec import PERSISTENT_DELIVERY_MODE
 
 
 class RabbitContext:
@@ -50,7 +51,8 @@ class RabbitContext:
             exchange=self._exchange,
             routing_key=self.queue_name,
             body=message,
-            properties=pika.BasicProperties(content_type=content_type))
+            properties=pika.BasicProperties(content_type=content_type, headers=headers,
+                                            delivery_mode=PERSISTENT_DELIVERY_MODE))
 
 
 class RabbitConnectionClosedError(Exception):

--- a/tests/test_rabbit_context.py
+++ b/tests/test_rabbit_context.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 from unittest.mock import patch
 
+from pika.spec import PERSISTENT_DELIVERY_MODE
+
 from rabbit_context import RabbitContext, RabbitConnectionClosedError
 
 
@@ -28,7 +30,7 @@ class TestRabbitContext(TestCase):
         with RabbitContext() as rabbit:
             rabbit.publish_message('Test message body', 'text')
 
-        patch_pika.BasicProperties.assert_called_once_with(content_type='text')
+        patch_pika.BasicProperties.assert_called_once_with(content_type='text', delivery_mode=PERSISTENT_DELIVERY_MODE)
         patched_basic_publish = patch_pika.BlockingConnection.return_value.channel.return_value.basic_publish
         patched_basic_publish.assert_called_once_with(exchange=rabbit._exchange,
                                                       routing_key=rabbit.queue_name,


### PR DESCRIPTION
Copied changes from Toolbox repository so now all RabbitContext relevant functions involved in publishing messages in QID Batch Runner are now in Persistent Delivery Mode.
