### PR TITLE
Changed uac quantity to 40

### DIFF
--- a/acceptance_tests/steps/valid_print_files.py
+++ b/acceptance_tests/steps/valid_print_files.py
@@ -1,7 +1,6 @@
 import csv
 import io
 import os
-import time
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
@@ -19,15 +18,8 @@ def generate_test_qid_batch(context):
     context.batch_config_path = Path(__file__).parents[1].resolve().joinpath('resources', 'acceptance_test_batch.csv')
     context.batch_id = uuid.uuid4()
     with rabbit_connection_and_channel() as (connection, channel):
-        purge_uac_queue(channel)
         request_test_qid_batch(context.batch_id)
         wait_for_uacs_to_be_created(connection, channel)
-
-
-def purge_uac_queue(channel):
-    time.sleep(15)  # Wait for rogue messages to finish being published
-    channel.queue_purge(queue='acceptance_tests_uac')  # Get rid of stuff not related to this test
-    time.sleep(15)  # Wait for the purge to finish
 
 
 def request_test_qid_batch(batch_id):
@@ -36,7 +28,7 @@ def request_test_qid_batch(batch_id):
         batch_id)
 
 
-def wait_for_uacs_to_be_created(connection, channel, timeout=30, expected_quantity=30):
+def wait_for_uacs_to_be_created(connection, channel, timeout=30, expected_quantity=40):
     def message_callback(channel, method, *_):
         nonlocal uac_message_count
         uac_message_count += 1


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Attempting to see the cause of the weird bugs in QID-batch runner. Saw that when it's waiting for the uacs to be created, it's waiting for a lower number than its expecting. It now generates 40 instead of 30 since `D_CCS_CHP2W` was added to the acceptance batch file. 

I've removed the previous changes Nick made, I'm happy to keep them in if people want me to keep them. I don't think they'll be necessary after this but it's hard to replicate locally.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the acceptance tests with this branch


# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/AieQ0yMG/541-investigate-the-qid-batch-runner-acceptance-test-error)