### PR TITLE
Making Dockerfile Use Non-root User

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ COPY Pipfile* /home/qidbatchrunner/
 RUN pipenv install --system --deploy
 USER qidbatchrunner
 
+RUN mkdir /home/qidbatchrunner/.postgresql
+
 COPY --chown=qidbatchrunner . /home/qidbatchrunner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
 FROM python:3.7-slim
 
-ENV RABBITMQ_SERVICE_HOST rabbitmq
+RUN pip install pipenv
+
+RUN groupadd --gid 1000 qidbatchrunner && useradd --create-home --system --uid 1000 --gid qidbatchrunner qidbatchrunner
+WORKDIR /home/qidbatchrunner
+
+ENV RABBITMQ_SERVICE_HOST=rabbitmq
 ENV RABBITMQ_SERVICE_PORT 5672
 ENV RABBITMQ_VHOST /
 ENV RABBITMQ_QUEUE unaddressedRequestQueue
 ENV RABBITMQ_USER guest
 ENV RABBITMQ_PASSWORD guest
 
-WORKDIR /app
-COPY . /app
-RUN pip install pipenv
+COPY Pipfile* /home/qidbatchrunner/
 RUN pipenv install --system --deploy
+USER qidbatchrunner
+
+COPY --chown=qidbatchrunner . /home/qidbatchrunner

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ You can watch the `unaddressedRequestQueue` from the rabbit management console t
 If you need to run a different config file, you can copy it into the pod once it is started with kubectl. 
 While the pod is running, in a different shell window run
 ```bash
-kubectl cp <local path to csv> qid-batch-runner:/app
+kubectl cp <local path to csv> qid-batch-runner:/home/qidbatchrunner
 ```
 
-Return to the connected shell in the pod, the file should then be available in the pod in `/app`.
+Return to the connected shell in the pod, the file should then be available in the pod in `/home/qidbatchrunner`.
 
 #### Generate the print files
 Once all the QID/UAC pair request messages have been ingested, you can generate the print files with

--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -29,7 +29,9 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - cp /home/qidbatchrunner/postgresql/* /home/qidbatchrunner/.postgresql && chmod 0600 /home/qidbatchrunner/.postgresql/postgresql.key
+                - |
+                cp /home/qidbatchrunner/postgresql/* /home/qidbatchrunner/.postgresql && 
+                chmod 0600 /home/qidbatchrunner/.postgresql/postgresql.key
         image: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner:latest
         imagePullPolicy: Always
         tty: true

--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -30,8 +30,8 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                cp /home/qidbatchrunner/postgresql/* /home/qidbatchrunner/.postgresql && 
-                chmod 0600 /home/qidbatchrunner/.postgresql/postgresql.key
+                  cp /home/qidbatchrunner/postgresql/* /home/qidbatchrunner/.postgresql && 
+                  chmod 0600 /home/qidbatchrunner/.postgresql/postgresql.key
         image: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner:latest
         imagePullPolicy: Always
         tty: true

--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: qid-batch-runner
-        image: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner:latest
+        image: adrhow92/census-rm-qid-batch-runner:latest
         imagePullPolicy: Always
         tty: true
         stdin: true
@@ -112,7 +112,7 @@ spec:
         - name: cloud-sql-certs
           secret:
             secretName: cloud-sql-certs
-            defaultMode: 0400
+            defaultMode: 0660
         - name: sftp-keys
           secret:
             secretName: sftp-ssh-credentials

--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -125,7 +125,7 @@ spec:
         - name: cloud-sql-certs
           secret:
             secretName: cloud-sql-certs
-            defaultMode: 0660
+            defaultMode: 0600
         - name: sftp-keys
           secret:
             secretName: sftp-ssh-credentials

--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -17,9 +17,20 @@ spec:
       labels:
         app: qid-batch-runner
     spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
       containers:
       - name: qid-batch-runner
-        image: adrhow92/census-rm-qid-batch-runner:latest
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - cp /home/qidbatchrunner/postgresql/* /home/qidbatchrunner/.postgresql && chmod 0600 /home/qidbatchrunner/.postgresql/postgresql.key
+        image: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner:latest
         imagePullPolicy: Always
         tty: true
         stdin: true
@@ -93,7 +104,7 @@ spec:
             value: "/home/qidbatchrunner/.pgp-keys/other_public_key.asc"
         volumeMounts:
           - name: cloud-sql-certs
-            mountPath: "/home/qidbatchrunner/.postgresql"
+            mountPath: "/home/qidbatchrunner/postgresql"
             readOnly: true
           - name: sftp-keys
             mountPath: "/home/qidbatchrunner/.sftp-ssh"

--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -86,20 +86,20 @@ spec:
                 name: sftp-ssh-credentials
                 key: passphrase
           - name: SFTP_KEY_FILENAME
-            value: "/root/.sftp-ssh/id_rsa"
+            value: "/home/qidbatchrunner/.sftp-ssh/id_rsa"
           - name: OUR_PUBLIC_KEY_PATH
-            value: "/root/.pgp-keys/our_public_key.asc"
+            value: "/home/qidbatchrunner/.pgp-keys/our_public_key.asc"
           - name: OTHER_PUBLIC_KEY_PATH
-            value: "/root/.pgp-keys/other_public_key.asc"
+            value: "/home/qidbatchrunner/.pgp-keys/other_public_key.asc"
         volumeMounts:
           - name: cloud-sql-certs
-            mountPath: "/root/.postgresql"
+            mountPath: "/home/qidbatchrunner/.postgresql"
             readOnly: true
           - name: sftp-keys
-            mountPath: "/root/.sftp-ssh"
+            mountPath: "/home/qidbatchrunner/.sftp-ssh"
             readOnly: true
           - name: pgp-keys
-            mountPath: "/root/.pgp-keys"
+            mountPath: "/home/qidbatchrunner/.pgp-keys"
             readOnly: true
         resources:
           requests:

--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -32,6 +32,7 @@ spec:
                 - |
                   cp /home/qidbatchrunner/postgresql/* /home/qidbatchrunner/.postgresql && 
                   chmod 0600 /home/qidbatchrunner/.postgresql/postgresql.key
+                  # the above is a workaround to get round the permissions as currently we cant mount it without doing this
         image: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner:latest
         imagePullPolicy: Always
         tty: true

--- a/qid-batch-runner.yml
+++ b/qid-batch-runner.yml
@@ -19,8 +19,6 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
-        runAsUser: 1000
-        runAsGroup: 1000
       containers:
       - name: qid-batch-runner
         lifecycle:

--- a/run_acceptance_tests.sh
+++ b/run_acceptance_tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-cd /app
+cd /home/qidbatchrunner
 behave acceptance_tests


### PR DESCRIPTION
# Motivation and Context
Changing the Dockerfile to use non-root user rather than root which makes it more secure (someone could gain root access to the Docker host by hacking the application running inside the container)

# What has changed
Created new user in Dockerfile and assigned permission levels. Also optimised the order in which the image is built. Changed k8s files to accommodate for making the Dockerfile use non-root user

# How to test? 
Clone and run ```make build``` to create Docker image and to run local tests. Run ATs locally and also in GCP

# Links
https://trello.com/c/Pd48zUsd
