### PR TITLE
Restore pipenv package vuln check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ install:
 	pipenv install --dev
 
 check:
-	# TODO reinstate this once https://github.com/pypa/pipenv/issues/4188 is resolved
-   #pipenv check
+   PIPENV_PYUP_API_KEY="" pipenv check
 
 lint:
 	pipenv run flake8


### PR DESCRIPTION
# Motivation and Context
Pipenv package vuln check was failing with an API key error.

# What has changed
Implemented workaround.

# How to test?
Run `make check`.

# Links
Trello: https://trello.com/c/AcwAmLZ4