### PR TITLE
feature/rabbitmq-guest-user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ENV RABBITMQ_SERVICE_HOST=rabbitmq
 ENV RABBITMQ_SERVICE_PORT 5672
 ENV RABBITMQ_VHOST /
 ENV RABBITMQ_QUEUE unaddressedRequestQueue
-ENV RABBITMQ_USER guest
-ENV RABBITMQ_PASSWORD guest
+ENV RABBITMQ_USER rmquser
+ENV RABBITMQ_PASSWORD rmqp455w0rd
 
 COPY Pipfile* /home/qidbatchrunner/
 RUN pipenv install --system --deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV RABBITMQ_SERVICE_PORT 5672
 ENV RABBITMQ_VHOST /
 ENV RABBITMQ_QUEUE unaddressedRequestQueue
 ENV RABBITMQ_USER rmquser
-ENV RABBITMQ_PASSWORD rmqp455w0rd
+ENV RABBITMQ_PASSWORD qpassword
 
 COPY Pipfile* /home/qidbatchrunner/
 RUN pipenv install --system --deploy

--- a/acceptance_tests/steps/valid_print_files.py
+++ b/acceptance_tests/steps/valid_print_files.py
@@ -51,8 +51,8 @@ def rabbit_connection_and_channel():
         pika.ConnectionParameters(os.getenv('RABBITMQ_SERVICE_HOST', 'localhost'),
                                   int(os.getenv('RABBITMQ_SERVICE_PORT', '6672')),
                                   os.getenv('RABBITMQ_VHOST', '/'),
-                                  pika.PlainCredentials(os.getenv('RABBITMQ_USER', 'guest'),
-                                                        os.getenv('RABBITMQ_PASSWORD', 'guest'))))
+                                  pika.PlainCredentials(os.getenv('RABBITMQ_USER', 'rmquser'),
+                                                        os.getenv('RABBITMQ_PASSWORD', 'rmqp455w0rd'))))
     channel = connection.channel()
     channel.exchange_declare(exchange='events', exchange_type='topic', durable=True)
     channel.queue_declare('acceptance_tests_uac', exclusive=True)

--- a/acceptance_tests/steps/valid_print_files.py
+++ b/acceptance_tests/steps/valid_print_files.py
@@ -52,7 +52,7 @@ def rabbit_connection_and_channel():
                                   int(os.getenv('RABBITMQ_SERVICE_PORT', '6672')),
                                   os.getenv('RABBITMQ_VHOST', '/'),
                                   pika.PlainCredentials(os.getenv('RABBITMQ_USER', 'rmquser'),
-                                                        os.getenv('RABBITMQ_PASSWORD', 'rmqp455w0rd'))))
+                                                        os.getenv('RABBITMQ_PASSWORD', 'qpassword'))))
     channel = connection.channel()
     channel.exchange_declare(exchange='events', exchange_type='topic', durable=True)
     channel.queue_declare('acceptance_tests_uac', exclusive=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,12 @@ version: '3'
 services:
   rabbitmq:
     container_name: rabbitmq
-    image: rabbitmq:3.6.10-management
+    image: rabbitmq:3.8-management
     ports:
       - "5369:4369"
       - "45672:25672"
       - "6671-6672:5671-5672"
       - "16671-16672:15671-15672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=rmquser
+      - RABBITMQ_DEFAULT_PASS=rmqp455w0rd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       - "16671-16672:15671-15672"
     environment:
       - RABBITMQ_DEFAULT_USER=rmquser
-      - RABBITMQ_DEFAULT_PASS=rmqp455w0rd
+      - RABBITMQ_DEFAULT_PASS=qpassword

--- a/rabbit_context.py
+++ b/rabbit_context.py
@@ -11,8 +11,8 @@ class RabbitContext:
         self._port = kwargs.get('port') or os.getenv('RABBITMQ_SERVICE_PORT', '6672')
         self._vhost = kwargs.get('vhost') or os.getenv('RABBITMQ_VHOST', '/')
         self._exchange = kwargs.get('exchange') or os.getenv('RABBITMQ_EXCHANGE', '')
-        self._user = kwargs.get('user') or os.getenv('RABBITMQ_USER', 'guest')
-        self._password = kwargs.get('password') or os.getenv('RABBITMQ_PASSWORD', 'guest')
+        self._user = kwargs.get('user') or os.getenv('RABBITMQ_USER', 'rmquser')
+        self._password = kwargs.get('password') or os.getenv('RABBITMQ_PASSWORD', 'rmqp455w0rd')
         self.queue_name = kwargs.get('queue_name') or os.getenv('RABBITMQ_QUEUE', 'unaddressedRequestQueue')
 
     def __enter__(self):

--- a/rabbit_context.py
+++ b/rabbit_context.py
@@ -12,7 +12,7 @@ class RabbitContext:
         self._vhost = kwargs.get('vhost') or os.getenv('RABBITMQ_VHOST', '/')
         self._exchange = kwargs.get('exchange') or os.getenv('RABBITMQ_EXCHANGE', '')
         self._user = kwargs.get('user') or os.getenv('RABBITMQ_USER', 'rmquser')
-        self._password = kwargs.get('password') or os.getenv('RABBITMQ_PASSWORD', 'rmqp455w0rd')
+        self._password = kwargs.get('password') or os.getenv('RABBITMQ_PASSWORD', 'qpassword')
         self.queue_name = kwargs.get('queue_name') or os.getenv('RABBITMQ_QUEUE', 'unaddressedRequestQueue')
 
     def __enter__(self):


### PR DESCRIPTION
Security best practise urges us not to use default account usernames and passwords.

- **`rmquser`** - is the new standard rabbitmq user
- **`rmqmanager`** - is new metrics and monitoring user
- **`guest`** is to be deleted manually after release

Important : Do not forget when testing to give a BRANCH variable feature/rabbitmq-guest-user so that apply-kubernetes can download the correct tmp_rm_kube
